### PR TITLE
Boost init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ compiler:
 - gcc
 - clang
 
+install:
+- sudo apt-get install libasio-dev
+
 before_script:
 - mkdir build && cd build
 - cmake ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
 cmake_minimum_required (VERSION 2.8)
 
+find_package(Boost REQUIRED)
+
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
 project(routing)
 
 add_library(routing Dummy.cpp)
+include_directories(${Boost_INCLUDE_DIRS})
+target_link_libraries(routing ${Boost_LIBRARIES})

--- a/src/Dummy.cpp
+++ b/src/Dummy.cpp
@@ -1,5 +1,9 @@
 #include <iostream>
+#include <boost/asio.hpp>
 
 int main () {
+    boost::asio::io_service io_dummy;
+    boost::asio::deadline_timer t(io_dummy, boost::posix_time::seconds(5));
+    t.wait();
     std::cout << "Hello word!" << std::endl;
 }


### PR DESCRIPTION
Adding Boost.Asio to the dependencies
- [x] Add the requirement for boost to the toplevel CMake file
- [x] Install asio in TravisCI before building
- [x] Test availability of boost to the project
- [x] :green_book: Build instructions: Get boost for Windows/Ubuntu
- [x] :green_book: Requirements: Minimum boost.asio Version required --> There is non yet, that's going to come later on
