### PR TITLE
BitDeli is basically dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Overlay router
 
-[![Build Status](https://travis-ci.org/elmo-net/overlay-routing.svg)](https://travis-ci.org/elmo-net/overlay-routing) [![Stories in Ready](https://badge.waffle.io/elmo-net/overlay-routing.svg?label=ready&title=Ready)](http://waffle.io/elmo-net/overlay-routing) [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/elmo-net/overlay-routing/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+[![Build Status](https://travis-ci.org/elmo-net/overlay-routing.svg)](https://travis-ci.org/elmo-net/overlay-routing) [![Stories in Ready](https://badge.waffle.io/elmo-net/overlay-routing.svg?label=ready&title=Ready)](http://waffle.io/elmo-net/overlay-routing)
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/elmo-net/overlay-routing?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


### PR DESCRIPTION
Reverts elmo-net/overlay-routing#18

With a little more reading on my side, I would have came come acrosse the blog entry mentioning the image proxying on GitHubs side and the date of that entry, being older that a year...
