### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A little library that implements a [Kademlia](http://www.maymounkov.org/papers/m
 
 ## :see_no_evil: How is the project
 
+Builds are triggered from GitHub. Linux binaries are built on [TravisCI](https://travis-ci.org/), Windows Builds are done on [AppVeyor](https://ci.appveyor.com/projects). Where no current support for C++14 is available, [Clang](http://clang.llvm.org/) is the compiler of choice. All platforms make use of the latest [CMake](http://www.cmake.org/) available to configure the build.
+
 [![Travis](https://img.shields.io/travis/elmo-net/router.svg?style=plastic)](https://travis-ci.org/elmo-net/router) on TravisCI
 
 [![](https://img.shields.io/appveyor/ci/HaMster21/router.svg?style=plastic)](https://ci.appveyor.com/project/HaMster21/router) on AppVeyor

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Builds are triggered from GitHub. Linux binaries are built on [TravisCI](https:/
 
 [![](https://img.shields.io/appveyor/ci/HaMster21/router.svg?style=plastic)](https://ci.appveyor.com/project/HaMster21/router) on AppVeyor
 
+[![Coveralls](https://img.shields.io/coveralls/elmo-net/router.svg?style=plastic)](https://coveralls.io/r/elmo-net/router)
+
 ## Join the Development
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/elmo-net/router?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # Router
 
-[![Build Status](https://travis-ci.org/elmo-net/router.svg?branch=master)](https://travis-ci.org/elmo-net/router) [![Documentation Status](https://readthedocs.org/projects/elmo-net-router/badge/?version=latest)](https://readthedocs.org/projects/elmo-net-router/?badge=latest) [![Stories in Ready](https://badge.waffle.io/elmo-net/router.svg?label=ready&title=Ready)](http://waffle.io/elmo-net/router)
+A little library that implements a [Kademlia](http://www.maymounkov.org/papers/maymounkov-kademlia-lncs.pdf) distributed hash-table. It's written in functional-style C++14. It is intended to work as a foundation for distributed scalable games on various platforms, focusing primarily on Linux.
+
+[![Latest version](https://img.shields.io/github/release/elmo-net/router.svg?style=plastic)](https://github.com/elmo-net/router/releases) [![GitHub Issues](https://img.shields.io/github/issues/elmo-net/router.svg?style=plastic)]() [![Documentation Status](https://img.shields.io/badge/Read%20the%20docs-latest-blue.svg?style=plastic)](http://elmo-net-router.rtfd.org/) [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=plastic)]()
+
+## :see_no_evil: How is the project
+
+[![Travis](https://img.shields.io/travis/elmo-net/router.svg?style=plastic)](https://travis-ci.org/elmo-net/router) on TravisCI
+
+[![](https://img.shields.io/appveyor/ci/HaMster21/router.svg?style=plastic)](https://ci.appveyor.com/project/HaMster21/router) on AppVeyor
+
+## Join the Development
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/elmo-net/router?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)
 
-## Summary
-
-This repository tries to implement a distributed hash-table in modern C++ with latest research results in mind. Starting off with the [Kademlia](https://en.wikipedia.org/wiki/Kademlia) protocol, this is aiming to be the foundation of distributed games in the future.
+[![Stories in Ready](https://badge.waffle.io/elmo-net/router.svg?label=ready&title=Ready)](http://waffle.io/elmo-net/router)


### PR DESCRIPTION
Switching to Shields.io for consistent badges.

This updates the README file to make the project status available on first sight. More details to come.
